### PR TITLE
Update Method to match EIP-1898 standard

### DIFF
--- a/mev_inspect/block.py
+++ b/mev_inspect/block.py
@@ -106,7 +106,7 @@ async def _fetch_block_timestamp(w3, block_number: int) -> int:
 
 
 async def _fetch_block_receipts(w3, block_number: int) -> List[Receipt]:
-    receipts_json = await w3.eth.get_block_receipts(block_number)
+    receipts_json = await w3.eth.get_block_receipts(hex(block_number))
     return [Receipt(**receipt) for receipt in receipts_json]
 
 


### PR DESCRIPTION
## What does this PR do?

Solves the following issue in mev inspect daemon
`{'code': -32602, 'message': 'Invalid params', 'data': 'invalid type: integer `22051918`, expected Block identifier following EIP-1898 at line 1 column 8'}`

## Related issue

Link to the issue this PR addresses.

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

After fixing it, the application was run in debug mode to ensure no other errors were popping up and mev-inpsect was able to communicate with RPC node properly

## Checklist before merging
- [ ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ ] Installed and ran pre-commit hooks
- [ ] All tests pass with `./mev test`
