### PR TITLE
Exception Handling in Listener

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -55,15 +55,21 @@ async def run():
     inspector = MEVInspector(rpc)
     base_provider = get_base_provider(rpc)
 
+
     while not killer.kill_now:
-        await inspect_next_block(
-            inspector,
-            inspect_db_session,
-            trace_db_session,
-            base_provider,
-            healthcheck_url,
-            export_actor,
-        )
+        try:
+            await inspect_next_block(
+                inspector,
+                inspect_db_session,
+                trace_db_session,
+                base_provider,
+                healthcheck_url,
+                export_actor,
+            )
+        except Exception as e:
+            logger.error(f"Error in inspect_next_block: {e}", exc_info=True)
+            logger.info("Pausing for 3 minutes before continuing...")
+            await asyncio.sleep(180)
 
     logger.info("Stopping...")
 


### PR DESCRIPTION
## What does this PR do?

Mev Listener Crashes and does not restart after getting an error. This PR ensures that it does not crash instead wait for 3 minutes and then continue with that block of transactions again. This helps avoid manual checking of logs and manual restarts to listener

## Related issue

Link to the issue this PR addresses.

If there isn't already an open issue, create an issue first. This will be our home for discussing the problem itself.

## Testing

What testing was performed to verify this works? Unit tests are a big plus!

## Checklist before merging
- [ ] Read the [contributing guide](https://github.com/flashbots/mev-inspect-py/blob/main/CONTRIBUTING.md)
- [ ] Installed and ran pre-commit hooks
- [ ] All tests pass with `./mev test`
