### PR TITLE
Fix/listener exception handling

### DIFF
--- a/listener.py
+++ b/listener.py
@@ -70,17 +70,19 @@ async def run():
             logger.error(f"Error in inspect_next_block: {e}", exc_info=True)
             # Close and re-create DB sessions to recover from invalid state
             try:
-                inspect_db_session.close()
+                if inspect_db_session is not None:
+                    inspect_db_session.close()
             except Exception as close_e:
                 logger.error(f"Error closing inspect_db_session: {close_e}")
             try:
-                trace_db_session.close()
+                if trace_db_session is not None:
+                    trace_db_session.close()
             except Exception as close_e:
                 logger.error(f"Error closing trace_db_session: {close_e}")
             inspect_db_session = get_inspect_session()
             trace_db_session = get_trace_session()
-            logger.info("Recreated DB sessions. Pausing for 2 minutes before continuing...")
-            await asyncio.sleep(120)
+            logger.info("Recreated DB sessions. Pausing for 1 minute before continuing...")
+            await asyncio.sleep(60)
 
     logger.info("Stopping...")
 

--- a/listener.py
+++ b/listener.py
@@ -68,8 +68,19 @@ async def run():
             )
         except Exception as e:
             logger.error(f"Error in inspect_next_block: {e}", exc_info=True)
-            logger.info("Pausing for 3 minutes before continuing...")
-            await asyncio.sleep(180)
+            # Close and re-create DB sessions to recover from invalid state
+            try:
+                inspect_db_session.close()
+            except Exception as close_e:
+                logger.error(f"Error closing inspect_db_session: {close_e}")
+            try:
+                trace_db_session.close()
+            except Exception as close_e:
+                logger.error(f"Error closing trace_db_session: {close_e}")
+            inspect_db_session = get_inspect_session()
+            trace_db_session = get_trace_session()
+            logger.info("Recreated DB sessions. Pausing for 2 minutes before continuing...")
+            await asyncio.sleep(120)
 
     logger.info("Stopping...")
 


### PR DESCRIPTION
## What does this PR do?

Listener Would Crash and not auto restart. This fixes that issue so that if the listener crashes due to any reason it can autorestart and continue working from the block it crashed on

Screenshot after testing:
<img width="896" height="811" alt="image" src="https://github.com/user-attachments/assets/9ca6ac72-a157-4999-9ecb-60294e1e4f7b" />

